### PR TITLE
Fix: avoid empty system prompts (Perplexity Sonar 400)

### DIFF
--- a/core/agents/system_prompts.py
+++ b/core/agents/system_prompts.py
@@ -110,7 +110,9 @@ def add_project_pages(ctx: RunContext) -> str:
 
         return instruction
     else:
-        return ""
+        # Some providers (e.g. Perplexity Sonar) reject empty system messages.
+        # Return an explicit no-op instruction instead of an empty string.
+        return "No internal project pages were provided for linking. Do not add internal links unless explicit URLs are provided in context."
 
 
 def add_title_details(ctx: RunContext[BlogPostGenerationContext]) -> str:
@@ -150,7 +152,8 @@ def add_target_keywords(ctx: RunContext[BlogPostGenerationContext]) -> str:
             Don't make them bold, just a regular part of the text.
         """  # noqa: E501
     else:
-        return ""
+        # Some providers reject empty system messages; keep this non-empty.
+        return "No specific SEO focus keywords were provided."
 
 
 def add_webpage_content(ctx: RunContext[WebPageContent]) -> str:

--- a/core/agents/title_suggestions_agent.py
+++ b/core/agents/title_suggestions_agent.py
@@ -51,7 +51,8 @@ def create_title_suggestions_agent(content_type=ContentType.SHARING, model=None)
     @agent.system_prompt
     def add_user_prompt(ctx: RunContext[TitleSuggestionContext]) -> str:
         if not ctx.deps.user_prompt:
-            return ""
+            # Some providers reject empty system messages.
+            return "No additional user prompt was provided."
 
         return f"""
             IMPORTANT USER REQUEST: The user has specifically requested the following:


### PR DESCRIPTION
This fixes a Perplexity Sonar 400 error: 'system message content cannot be empty or contain only whitespace'.

Root cause: several @agent.system_prompt helper functions returned an empty string (e.g. when no project pages / no keywords / no user_prompt). Some providers reject empty system messages.

Change: return an explicit non-empty no-op instruction instead of an empty string in:
- core/agents/system_prompts.py:add_project_pages (no project pages)
- core/agents/system_prompts.py:add_target_keywords (no focus keywords)
- core/agents/title_suggestions_agent.py:add_user_prompt (no user prompt)

This prevents request construction from including invalid empty system messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced system prompt consistency to ensure AI agents receive non-empty guidance messages when optional user inputs are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->